### PR TITLE
Fix the calculation of block chance

### DIFF
--- a/captchas.ts
+++ b/captchas.ts
@@ -109,7 +109,7 @@ function hit_cap_generator(): {answer: string, seed: string, text: string} {
                 const block_chance = front ? Math.min(5, 5 + skill_delta * 0.1) : 0;
                 answer = block_chance;
                 attack_query = "the chance that your attacks are blocked (rounded up to nearest 1/10th)?";
-                answer_example = "4.2";
+                answer_example = "14.2";
                 break;
             case "dodge":
                 const dodge_chance = 5 + skill_delta * 0.1;

--- a/captchas.ts
+++ b/captchas.ts
@@ -106,10 +106,10 @@ function hit_cap_generator(): {answer: string, seed: string, text: string} {
                 answer_example = "19.4";
                 break;
             case "block":
-                const block_chance = front ? 0 : Math.min(5, 5 + skill_delta * 0.1);
-                answer = Math.ceil(block_chance / 10) * 10;
+                const block_chance = front ? Math.min(5, 5 + skill_delta * 0.1) : 0;
+                answer = block_chance;
                 attack_query = "the chance that your attacks are blocked (rounded up to nearest 1/10th)?";
-                answer_example = "14.2";
+                answer_example = "4.2";
                 break;
             case "dodge":
                 const dodge_chance = 5 + skill_delta * 0.1;


### PR DESCRIPTION
Block chance was being calculated incorrectly.

The check for `front` was backwards.

Additionally the returned block chance does not have to be rounded like others.