### PR TITLE
Quiz structure for handling asking 3 unique captchas and failing if too many wrong answers

### DIFF
--- a/migrations/1577927863800_create-quiz.js
+++ b/migrations/1577927863800_create-quiz.js
@@ -1,0 +1,45 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+    pgm.createTable("quizs", {
+        id: {
+            type: "uuid",
+            default: pgm.func("uuid_generate_v4()"),
+            notNull: true
+        },
+        user_id: {
+            type: "varchar(1000)",
+            notNull: true
+        },
+        active: {
+            type: "boolean",
+            default: true,
+            notNull: true
+        },
+        completed: {
+            type: "integer",
+            default: 0,
+            notNull: true
+        },
+        wrong: {
+            type: "integer",
+            default: 0,
+            notNull: true
+        },
+        updatedAt: {
+            type: "timestamp",
+            notNull: true,
+        },
+        createdAt: {
+            type: "timestamp",
+            notNull: true,
+        },
+    });
+    pgm.createIndex("quizs", "id");
+};
+
+exports.down = (pgm) => {
+    pgm.dropTable("quizs", { ifExists: true });
+};

--- a/migrations/1577932324349_add-captcha-quizid.js
+++ b/migrations/1577932324349_add-captcha-quizid.js
@@ -1,0 +1,24 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+    pgm.addColumns("captchas", {
+        text: {
+            type: "varchar(1000)",
+            default: "",
+            notNull: true,
+        },
+        quiz_id: {
+            type: "varchar(1000)",
+            default: "",
+            notNull: true,
+        }
+    });
+    pgm.createIndex("captchas", "user_id");
+};
+
+exports.down = (pgm) => {
+    pgm.dropColumns("captchas", ["text", "quiz_id"])
+    pgm.dropIndex("captchas", "user_id");
+};

--- a/src/captchas.ts
+++ b/src/captchas.ts
@@ -162,7 +162,6 @@ export function hit_cap_generator(_scenario?: CombatScenario,
 
     return {
         answer: Math.max(0, answer).toFixed(1),
-        seed: (Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 32) + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 32)).toUpperCase(),
         text: `${scenario_txt}\n\n${question}\n\n*Experiencing problems with my programming? [Open an issue](https://github.com/Kruhlmann/gatekeeper/issues/new?assignees=Kruhlmann&labels=bug&template=captcha-issue.md&title=%5BCAPTCHA%5D)*`
     };
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -18,9 +18,21 @@ let instance: DB;
 export class Captcha extends Model {
     public id!: string;
     public user_id!: string;
+    public quiz_id!: string;
+    public text!: string;
     public answer!: string;
     public active!: boolean;
     public completed!: boolean;
+    public readonly createdAt!: Date;
+    public readonly updatedAt!: Date;
+};
+
+export class Quiz extends Model {
+    public id!: string;
+    public user_id!: string;
+    public active!: boolean;
+    public wrong!: number;
+    public completed!: number;
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 };
@@ -52,11 +64,19 @@ export class DB {
                 primaryKey: true,
             },
             user_id: {
-                type: DataTypes.STRING(256),
+                type: DataTypes.STRING(1000),
+                allowNull: false,
+            },
+            quiz_id: {
+                type: DataTypes.STRING(1000),
+                allowNull: false,
+            },
+            text: {
+                type: DataTypes.STRING(1000),
                 allowNull: false,
             },
             answer: {
-                type: DataTypes.STRING(256),
+                type: DataTypes.STRING(1000),
                 allowNull: false,
             },
             active: {
@@ -72,6 +92,38 @@ export class DB {
         }, {
             sequelize: this.connection,
             tableName: "captchas",
+        });
+
+
+        Quiz.init({
+            id: {
+                type: DataTypes.UUID,
+                defaultValue: Sequelize.literal("uuid_generate_v4()"),
+                allowNull: false,
+                primaryKey: true,
+            },
+            user_id: {
+                type: DataTypes.STRING(1000),
+                allowNull: false,
+            },
+            active: {
+                type: DataTypes.BOOLEAN,
+                defaultValue: true,
+                allowNull: false,
+            },
+            wrong: {
+                type: DataTypes.INTEGER,
+                defaultValue: 0,
+                allowNull: false,
+            },
+            completed: {
+                type: DataTypes.INTEGER,
+                defaultValue: 0,
+                allowNull: false,
+            }
+        }, {
+            sequelize: this.connection,
+            tableName: "quizs",
         });
     }
 }

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -32,7 +32,5 @@ export interface CombatScenario {
 
 export interface Captcha {
     answer: string;
-    seed: string;
     text: string;
 }
-


### PR DESCRIPTION
Added Quiz table that handles the captchas, used for storing the number of correct captcha solves and the number of wrong answers.

Captchas are looked up for by this quiz_id. The captchas are generated at the start with questions/answers and stored in the database for sending at a later date.

If you answer wrong 5 times you fail the quiz.

This should solve issue #37 