### PR TITLE
Fix potential race when looking up next captcha to send

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -282,7 +282,7 @@ function validate_environment(variable_keys: string[]): boolean {
 
                     psql.Captcha.findOne({
                         where: {
-                            [Op.and]: [{ quiz_id: q.id }, { completed: false }]
+                            [Op.and]: [{ quiz_id: q.id, completed: false, active: false }]
                         }
                     }).then((c: psql.Captcha) => {
                         c.update({active: true}).then((c: psql.Captcha) => {


### PR DESCRIPTION
Change the search for the next captcha to send to also filter by active:false instead of only completed:false, this ensures we don't accidentally select the current captcha that has completed:false and active:true